### PR TITLE
chore(ci): re-pin supply-chain-guard to v5.2.37 + enable Dependabot

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,52 +3,52 @@
   "project": "repo",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782537119",
-    "timestamp": "2026-06-27T05:11:59Z",
+    "session_id": "cli-1782537650",
+    "timestamp": "2026-06-27T05:20:51Z",
     "commit": "c9deca9",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:ff676dacc4877c3cea09985505eee07700ecb8146f0b217d5e69a3963e9e3489",
-      "updated": "2026-06-27T05:11:42Z",
+      "checksum": "sha256:02c9a741afb6a828442175a79f041cee4610acd97a3329c8467962061c5cb602",
+      "updated": "2026-06-27T05:19:50Z",
       "lines": 116,
       "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:39bf386720ea848f757f612fb0c54a2b9748a8c045f67dcc39135227139023f1",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 161,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:1866198867e29686c18b1b3959cf2bdc05f56256d1d76ac74bd145630098f539",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 143,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:98e90f05c1270e5e20668bbd43cb1a0a0913cd93b1069f110810604e6a0fc535",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:ad6a227d8417c6d4567b03306670f93893670774acc2f47353ce3510bee08b06",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:c623185d1113acbc3c480d956880b2e539e5e82131e67e6405c956bb56ef4638",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 116,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:308f72affaf98d060daf61aa18465a196d11e348e2f027ee3dc2965b8776dd99",
-      "updated": "2026-06-27T05:07:31Z",
+      "updated": "2026-06-27T05:19:49Z",
       "lines": 151,
       "summary": "﻿# aahp-orchestrator: Autonomous Multi-Agent Workflow"
     }
@@ -56,7 +56,7 @@
   "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3228,
-    "full_read": 9018
+    "manifest_plus_core": 3245,
+    "full_read": 9016
   }
 }

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -1,62 +1,62 @@
 {
   "aahp_version": "3.0",
-  "project": "aahp-orchestrator",
+  "project": "repo",
   "last_session": {
-    "agent": "cli-tool",
-    "session_id": "cli-1782474405",
-    "timestamp": "2026-06-26T11:46:45Z",
-    "commit": "ec36a28",
-    "phase": "fix",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1782537119",
+    "timestamp": "2026-06-27T05:11:59Z",
+    "commit": "c9deca9",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:301f808cea7e0dc72f4ebe0a4e1678c8b450ee407856417976c7ad746c6557fa",
-      "updated": "2026-06-26T11:45:53Z",
-      "lines": 114,
-      "summary": "(no summary available)"
+      "checksum": "sha256:ff676dacc4877c3cea09985505eee07700ecb8146f0b217d5e69a3963e9e3489",
+      "updated": "2026-06-27T05:11:42Z",
+      "lines": 116,
+      "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:39bf386720ea848f757f612fb0c54a2b9748a8c045f67dcc39135227139023f1",
-      "updated": "2026-06-26T09:34:48Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 161,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:1866198867e29686c18b1b3959cf2bdc05f56256d1d76ac74bd145630098f539",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 143,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:98e90f05c1270e5e20668bbd43cb1a0a0913cd93b1069f110810604e6a0fc535",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:ad6a227d8417c6d4567b03306670f93893670774acc2f47353ce3510bee08b06",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:c623185d1113acbc3c480d956880b2e539e5e82131e67e6405c956bb56ef4638",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 116,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:308f72affaf98d060daf61aa18465a196d11e348e2f027ee3dc2965b8776dd99",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-06-27T05:07:31Z",
       "lines": 151,
-      "summary": "(no summary available)"
+      "summary": "﻿# aahp-orchestrator: Autonomous Multi-Agent Workflow"
     }
   },
-  "quick_context": "(no summary available) (no summary available)",
+  "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
     "manifest_plus_core": 3228,
-    "full_read": 8999
+    "full_read": 9018
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -112,3 +112,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-21 ci: add supply-chain-guard v5.2.35 Action workflow (fail-on critical).
 
 > 2026-06-21 ci(aahp): fix unquoted next_task_id + lint-handoff noreply@ PII exclusion.
+
+> 2026-06-27 ci: re-pin supply-chain-guard to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b); enable Dependabot github-actions weekly updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: homeofe/supply-chain-guard@89a0f2c97ff866b939b9adf8709d8b431683d937  # v5.2.35
+      - uses: homeofe/supply-chain-guard@be1d718b17cc38e4bce7fa48579b7112e557943b  # v5.2.37
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Re-pins the supply-chain-guard action from v5.2.35 (89a0f2c97ff866b939b9adf8709d8b431683d937) to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b), which includes the PR-comment crash fix (no more red Scan), and enables weekly Dependabot github-actions updates.