### PR TITLE
docs(readme): add AAHP Verify + CI badges

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,52 +3,52 @@
   "project": "repo",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782537650",
-    "timestamp": "2026-06-27T05:20:51Z",
-    "commit": "c9deca9",
+    "session_id": "cli-1782541099",
+    "timestamp": "2026-06-27T06:18:21Z",
+    "commit": "4b45c75",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:02c9a741afb6a828442175a79f041cee4610acd97a3329c8467962061c5cb602",
-      "updated": "2026-06-27T05:19:50Z",
-      "lines": 116,
+      "checksum": "sha256:94a5cbeec08245a4aef260382d6d5315469e736af4fa30d9818de410cf5d8f6a",
+      "updated": "2026-06-27T06:17:48Z",
+      "lines": 118,
       "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:39bf386720ea848f757f612fb0c54a2b9748a8c045f67dcc39135227139023f1",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 161,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:1866198867e29686c18b1b3959cf2bdc05f56256d1d76ac74bd145630098f539",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 143,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:98e90f05c1270e5e20668bbd43cb1a0a0913cd93b1069f110810604e6a0fc535",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:ad6a227d8417c6d4567b03306670f93893670774acc2f47353ce3510bee08b06",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:c623185d1113acbc3c480d956880b2e539e5e82131e67e6405c956bb56ef4638",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 116,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:308f72affaf98d060daf61aa18465a196d11e348e2f027ee3dc2965b8776dd99",
-      "updated": "2026-06-27T05:19:49Z",
+      "updated": "2026-06-27T06:16:31Z",
       "lines": 151,
       "summary": "﻿# aahp-orchestrator: Autonomous Multi-Agent Workflow"
     }
@@ -56,7 +56,7 @@
   "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3245,
-    "full_read": 9016
+    "manifest_plus_core": 3271,
+    "full_read": 9042
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -114,3 +114,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-21 ci(aahp): fix unquoted next_task_id + lint-handoff noreply@ PII exclusion.
 
 > 2026-06-27 ci: re-pin supply-chain-guard to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b); enable Dependabot github-actions weekly updates.
+
+> 2026-06-27 docs(readme): add CI, AAHP Verify, and Security workflow status badges to README badge block (matches canonical homeofe/AAHP style).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 > VS Code extension - orchestrate GitHub Copilot and Claude Code with AAHP v3 context. Zero questions. Full context. Both agents know what to do.
 
+[![CI](https://github.com/homeofe/aahp-orchestrator/actions/workflows/ci.yml/badge.svg)](https://github.com/homeofe/aahp-orchestrator/actions/workflows/ci.yml)
+[![AAHP Verify](https://github.com/homeofe/aahp-orchestrator/actions/workflows/aahp-verify.yml/badge.svg)](https://github.com/homeofe/aahp-orchestrator/actions/workflows/aahp-verify.yml)
+[![Security](https://github.com/homeofe/aahp-orchestrator/actions/workflows/codeql.yml/badge.svg)](https://github.com/homeofe/aahp-orchestrator/actions/workflows/codeql.yml)
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/elvatis.aahp-orchestrator?label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=elvatis.aahp-orchestrator)
 [![VS Code](https://img.shields.io/badge/VS%20Code-%5E1.116-blue)](https://code.visualstudio.com/)
 [![AAHP v3](https://img.shields.io/badge/AAHP-v3-green)](https://github.com/homeofe/AAHP)


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow status badges to the README badge block, matching the canonical homeofe/AAHP README style.

Added badges (only for workflows that actually exist in `.github/workflows/`):
- **CI** -> `ci.yml`
- **AAHP Verify** -> `aahp-verify.yml`
- **Security** -> `codeql.yml`

Existing badges (Marketplace, VS Code, AAHP v3, License) are preserved; no duplicates.

## AAHP handoff

This repo is AAHP-gated, so the handoff was bumped alongside the docs change:
- Appended a dated note to `.ai/handoff/STATUS.md`.
- Regenerated `.ai/handoff/MANIFEST.json` with HEAD at the base commit so the manifest commit-pointer matches base (keeps a future squash Layer-3-green).
- `bash scripts/verify-handoff.sh . --level ci` passes all 4 layers locally.

## Files changed
- `README.md`
- `.ai/handoff/STATUS.md`
- `.ai/handoff/MANIFEST.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)