### PR TITLE
ci: track supply-chain-guard @v5 instead of stale SHA pins

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,18 +2,18 @@
   "aahp_version": "3.0",
   "project": "aahp-orchestrator",
   "last_session": {
-    "agent": "claude-opus-4-8",
-    "session_id": "cli-1782817879",
-    "timestamp": "2026-06-30T11:11:20Z",
-    "commit": "d207d7c",
+    "agent": "claude-fable-5",
+    "session_id": "cli-1783072038",
+    "timestamp": "2026-07-03T09:47:18Z",
+    "commit": "b1b9465",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:410867fe7afe1fbd440b5a37c3db3dc3e9079255b712a2633a7699b506bb34fd",
-      "updated": "2026-06-30T11:11:19Z",
-      "lines": 126,
+      "checksum": "sha256:e223768079d279b7d0f21574b48a10889b7e0b3a25377f6bb10347100eb7ab88",
+      "updated": "2026-07-03T09:47:18Z",
+      "lines": 127,
       "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
@@ -62,7 +62,7 @@
   "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3413,
-    "full_read": 9192
+    "manifest_plus_core": 3466,
+    "full_read": 9245
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -124,3 +124,4 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-30 verify: added reviewed expiring PII allowlist, rolled out from AAHP v3.2.0.
 
 > 2026-06-30 ci: exempt Dependabot from the aahp-verify handoff gate (keep supply-chain-guard/codeql/build).
+- 2026-07-03: ci: supply-chain-guard now tracks the moving @v5 release branch instead of a stale SHA pin (owner rule: consumers pin @v5, the release workflow moves it - currently v5.6.1). Ends the recurring stale/broken-pin churn (v5.2.35 crash wave). Config change only.

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: homeofe/supply-chain-guard@ea00551de8e8a95bc1bf4533acb5bf7f883e3132  # v5.2.43
+      - uses: homeofe/supply-chain-guard@v5
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Owner rule (2026-07-03): consumer repos pin the moving @v5 release branch; the scg release workflow advances it (currently v5.6.1). SHA pins across the estate had drifted onto stale or broken releases (three repos sat on the crashing v5.2.35 this week). Config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)