### PR TITLE
fix(gate): sync Layer 3 tolerance (WARN on non-ancestor pointer)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,59 +2,59 @@
   "aahp_version": "3.0",
   "project": "aahp-orchestrator",
   "last_session": {
-    "agent": "claude-fable-5",
-    "session_id": "cli-1783072038",
-    "timestamp": "2026-07-03T09:47:18Z",
-    "commit": "b1b9465",
-    "phase": "fix",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1784009934",
+    "timestamp": "2026-07-14T06:18:54Z",
+    "commit": "87fb417",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:e223768079d279b7d0f21574b48a10889b7e0b3a25377f6bb10347100eb7ab88",
-      "updated": "2026-07-03T09:47:18Z",
-      "lines": 127,
+      "checksum": "sha256:c81480a694a5146df6d917bb803711b86c39d0f5c8c98dda8037f8b83466a85f",
+      "updated": "2026-07-14T06:18:54Z",
+      "lines": 129,
       "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:2ef9090e94b9e0f7b84aaea8c67e6971c507b2ba1dac53e1ab659cd092b27287",
-      "updated": "2026-06-28T10:10:31Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 161,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:1866198867e29686c18b1b3959cf2bdc05f56256d1d76ac74bd145630098f539",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 143,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:98e90f05c1270e5e20668bbd43cb1a0a0913cd93b1069f110810604e6a0fc535",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:ad6a227d8417c6d4567b03306670f93893670774acc2f47353ce3510bee08b06",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:c623185d1113acbc3c480d956880b2e539e5e82131e67e6405c956bb56ef4638",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 116,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:308f72affaf98d060daf61aa18465a196d11e348e2f027ee3dc2965b8776dd99",
-      "updated": "2026-04-14T10:40:13Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 151,
       "summary": "﻿# aahp-orchestrator: Autonomous Multi-Agent Workflow"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-30T09:39:07Z",
+      "updated": "2026-07-14T06:18:53Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,7 +62,7 @@
   "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3466,
-    "full_read": 9245
+    "manifest_plus_core": 3522,
+    "full_read": 9301
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
+
 ﻿# aahp-orchestrator: Current State of the Nation
 
 > Last updated: 2026-06-28 by claude-opus-4-8

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -231,8 +231,7 @@ if [ "$LEVEL" != "precommit" ]; then
             # Layer 2 already enforced that. Here we just inform.
             log_warn "MANIFEST commit ($MANIFEST_COMMIT) is behind HEAD ($HEAD_SHORT). Run /handoff if code changed."
         else
-            log_fail "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). Stale manifest. Run /handoff."
-            FAILURES=$((FAILURES + 1))
+            log_warn "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). A squash-merge or rebase-merge orphans the branch-local pointer; Layers 1-2 gate real staleness. Run /handoff if code changed."
         fi
     fi
 fi


### PR DESCRIPTION
Syncs the canonical Layer 3 tolerance fix from [homeofe/improvements#12](https://github.com/homeofe/improvements/pull/12). `verify-handoff.sh` Layer 3 now downgrades a non-ancestor `MANIFEST.last_session.commit` from FAIL to WARN, so a squash-merge or rebase-merge no longer trips `AAHP Verify` on main. Layers 1-2 keep gating real staleness; the missing-MANIFEST hard-fail is unchanged. Manifest regenerated against the base commit. Verified locally: 0 checksum mismatches, bash -n clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>