### PR TITLE
chore(aahp): sync canonical gate scripts and hook tooling from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,58 +3,58 @@
   "project": "aahp-orchestrator",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1784009934",
-    "timestamp": "2026-07-14T06:18:54Z",
-    "commit": "87fb417",
-    "phase": "implementation",
+    "session_id": "cli-1784032506",
+    "timestamp": "2026-07-14T12:35:10Z",
+    "commit": "c3ec3dd",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:c81480a694a5146df6d917bb803711b86c39d0f5c8c98dda8037f8b83466a85f",
-      "updated": "2026-07-14T06:18:54Z",
-      "lines": 129,
+      "checksum": "sha256:33aef4750b51b4d240e15f8e601439e5b804791262a3a4f9bcdbc9bdae72d533",
+      "updated": "2026-07-14T12:32:02Z",
+      "lines": 131,
       "summary": "﻿# aahp-orchestrator: Current State of the Nation"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:2ef9090e94b9e0f7b84aaea8c67e6971c507b2ba1dac53e1ab659cd092b27287",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 161,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:1866198867e29686c18b1b3959cf2bdc05f56256d1d76ac74bd145630098f539",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 143,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:98e90f05c1270e5e20668bbd43cb1a0a0913cd93b1069f110810604e6a0fc535",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 131,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:ad6a227d8417c6d4567b03306670f93893670774acc2f47353ce3510bee08b06",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:c623185d1113acbc3c480d956880b2e539e5e82131e67e6405c956bb56ef4638",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 116,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:308f72affaf98d060daf61aa18465a196d11e348e2f027ee3dc2965b8776dd99",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 151,
       "summary": "﻿# aahp-orchestrator: Autonomous Multi-Agent Workflow"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T06:18:53Z",
+      "updated": "2026-07-14T12:29:54Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,7 +62,7 @@
   "quick_context": "﻿# aahp-orchestrator: Current State of the Nation (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 3522,
-    "full_read": 9301
+    "manifest_plus_core": 3567,
+    "full_read": 9346
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical AAHP gate scripts from homeofe/improvements (v3.5.0 fixes: aahp-manifest.sh --phase documentation + cross_repo_ref preservation, lint-handoff.sh SC2034), AAHP_HANDOFF_FILES preserved, and refreshed the local hook tooling (scripts/hooks/, install-hooks.sh, verify-hooks.sh). Fleet re-sync.
+
 > Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
 
 ﻿# aahp-orchestrator: Current State of the Nation

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -2,7 +2,17 @@
 # _aahp-lib.sh -Shared functions for AAHP tooling
 # Not intended to be run directly. Source this from other scripts.
 
-# Standard AAHP handoff files, in canonical order
+# Standard AAHP handoff files, in canonical order.
+#
+# PER-REPO CONFIG: this single line is the one legitimate point of variation
+# across consumer repos. It is the DEFAULT / superset used for a fresh install;
+# a consumer that tracks fewer files (e.g. no LOG-ARCHIVE.* or no
+# pii-allowlist.json) keeps its own narrower list. scripts/sync-gate-scripts.sh
+# treats exactly this line as per-repo-preserved: when it copies the canonical
+# gate scripts into a consumer it reads the consumer's existing
+# AAHP_HANDOFF_FILES=(...) line and substitutes it back in, so a sync never
+# overwrites a repo's tracked-file set. aahp-manifest.sh only indexes files that
+# actually exist, so listing a file a repo does not have is harmless.
 # shellcheck disable=SC2034
 AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
@@ -50,7 +60,11 @@ aahp_line_count() {
 aahp_auto_summary() {
     local filepath="$1"
     local summary
+    # Strip CR so a CRLF working tree (Windows) yields the same summary as an
+    # LF checkout (Linux CI). The summary is written to the non-checksummed
+    # "summary" field, so this is a cosmetic robustness fix, not a gate change.
     summary=$(head -5 "$filepath" \
+        | tr -d '\r' \
         | grep -v '^#' | grep -v '^>' | grep -v '^---' | grep -v '^$' \
         | head -1 | cut -c1-150 || true)
     [ -z "$summary" ] && summary="(no summary available)"

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --agent NAME       Agent identifier (default: "cli-tool")
 #   --session-id ID    Session identifier (default: auto-generated)
-#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle (default: "idle")
+#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle|documentation (default: "idle")
 #   --context "TEXT"    Quick context string (default: auto-generated from file summaries)
 #   --duration MIN     Session duration in minutes (default: 0)
 #   --quiet            Suppress output except errors
@@ -67,16 +67,27 @@ fi
 
 # Validate phase
 case "$PHASE" in
-    research|architecture|implementation|review|fix|idle) ;;
+    research|architecture|implementation|review|fix|idle|documentation) ;;
     *)
-        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle" >&2
+        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle, documentation" >&2
         exit 1
         ;;
 esac
 
 # ─── Detect project metadata ─────────────────────────────────
 
-PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+# Project name: PRESERVE the existing MANIFEST.json "project" value on
+# regeneration; only derive it from the directory basename on first-ever
+# generation. Without this, regenerating inside a differently-named checkout
+# (e.g. the gate-sync bot's mktemp working copy, or any tarball/CI dir) would
+# overwrite a consumer's real project name with the temp-dir basename.
+PROJECT_NAME=""
+if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
+    PROJECT_NAME="$(aahp_manifest_field "$HANDOFF_DIR/MANIFEST.json" "project")"
+fi
+if [ -z "$PROJECT_NAME" ]; then
+    PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+fi
 COMMIT=$(cd "$PROJECT_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -140,23 +151,33 @@ FULL_TOKENS=$((MANIFEST_TOKENS + TOTAL_TOKENS))
 
 TASKS_JSON=""
 NEXT_TASK_ID=""
+CROSS_REPO_REF=""
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
     if command -v node &>/dev/null; then
         EXISTING=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.tasks) process.stdout.write(JSON.stringify(m.tasks));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING" ]; then
             TASKS_JSON="$EXISTING"
         fi
         EXISTING_ID=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.next_task_id) process.stdout.write(String(m.next_task_id));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
+        fi
+        # Preserve the optional cross_repo_ref field (v3.4+), like tasks it is
+        # agent-managed and must survive regeneration.
+        EXISTING_CRR=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            if (m.cross_repo_ref) process.stdout.write(JSON.stringify(m.cross_repo_ref));
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
+        if [ -n "$EXISTING_CRR" ]; then
+            CROSS_REPO_REF="$EXISTING_CRR"
         fi
     fi
 fi
@@ -193,6 +214,9 @@ MANIFEST
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"
     fi
+    if [ -n "$CROSS_REPO_REF" ]; then
+        echo "  ,\"cross_repo_ref\": $CROSS_REPO_REF"
+    fi
 
     echo "}"
 } > "$HANDOFF_DIR/MANIFEST.json"
@@ -203,3 +227,5 @@ if [ "$QUIET" = false ]; then
     echo "MANIFEST.json generated: $FILES_FOUND files indexed, checksums current."
     echo "  Token budget: manifest=$MANIFEST_TOKENS, core=$CORE_TOKENS, full=$FULL_TOKENS"
 fi
+
+

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -41,13 +41,13 @@ HOOKS_DIR=$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)
 if [ -n "$HOOKS_DIR" ]; then
     # core.hooksPath may be relative to the repo root.
     case "$HOOKS_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
     esac
 else
     GIT_DIR=$(git -C "$TARGET" rev-parse --git-dir)
     case "$GIT_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) GIT_DIR="$TARGET/$GIT_DIR" ;;
     esac
     HOOKS_DIR="$GIT_DIR/hooks"

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -37,6 +37,18 @@ PROJECT_ROOT="."
 HANDOFF_DIR=".ai/handoff"
 VIOLATIONS=0
 
+# Resolve validate-pii-allowlist.py as a path RELATIVE to the (post-cd) cwd, so
+# native-Windows python is handed a relative path rather than an absolute MSYS
+# one. An absolute /c/Users/... path intermittently fails MSYS->Windows argv
+# conversion and surfaces as a mangled "C:\c\Users\...: can't open file"
+# artifact (a false Check-3 failure). realpath --relative-to is coreutils
+# (present on git-bash and Linux CI); where it is unavailable (e.g. BSD realpath
+# on macOS) we keep the absolute path, which opens fine there.
+PII_VALIDATOR="$SCRIPT_DIR/validate-pii-allowlist.py"
+if PII_VALIDATOR_REL="$(realpath --relative-to="$PWD" "$SCRIPT_DIR/validate-pii-allowlist.py" 2>/dev/null)"; then
+    PII_VALIDATOR="$PII_VALIDATOR_REL"
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -136,7 +148,7 @@ if [ -f "$ALLOWLIST_FILE" ]; then
         VIOLATIONS=$((VIOLATIONS + 1))
     else
         ALLOWLIST_ERR="$(mktemp)"
-        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
+        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$PII_VALIDATOR" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
             echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
         else
             ALLOWLIST_MESSAGE="$ALLOWLIST_ENTRIES"
@@ -170,13 +182,21 @@ PY
     fi
 fi
 
+# Locale-robustness (T-027): use grep -E (POSIX ERE), never grep -P (PCRE). GNU
+# grep -P aborts under a non-UTF-8 locale ("supports only unibyte and UTF-8
+# locales") and the pipeline then finds nothing, a silent FALSE PASS that made
+# the gate non-deterministic by locale. LC_ALL=C.UTF-8 pins byte-for-byte
+# identical detection across Windows git-bash, the commit hook, and Linux CI.
+# Per-MATCH filtering (T-029): grep -o extracts each address, awk excludes per
+# ADDRESS (not per line), so an excluded token (noreply / example.com /
+# placeholder) elsewhere on the same line can no longer mask a real address.
 EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null | awk -F: '{ addr=$NF; if (addr ~ /\.noreply\./ || addr ~ /^no-?reply@/ || index(addr,"example.com") || index(addr,"placeholder")) next; print }' || true)
 UNAPPROVED=""
 if [ -n "$EMAIL_MATCHES" ]; then
     while IFS= read -r match; do
         address="${match##*:}"
         allowed=0
-        while IFS=$'\t' read -r value owner expires reason; do
+        while IFS=$'\t' read -r value owner expires _; do
             [ -z "$value" ] && continue
             if [ "$address" = "$value" ]; then
                 echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -82,7 +82,16 @@ case "$LEVEL" in
         ;;
 esac
 
-HANDOFF_DIR="$PROJECT_ROOT/.ai/handoff"
+# Path-format-agnostic file access (cross-platform fix).
+# Windows-native Python/Node cannot open an absolute MSYS path like
+# /c/Users/...; helpers that read MANIFEST.json (aahp_manifest_field) would
+# fail. Change into the project root once, then drive everything off RELATIVE
+# paths (lint-handoff.sh ".", git -C ".", '.ai/handoff/...'); these resolve
+# identically on Windows git-bash and Linux CI. SCRIPT_DIR was already resolved
+# above against $0, so sourcing/exec of sibling scripts is unaffected by the cd.
+cd "$PROJECT_ROOT" || { echo -e "${RED}Error: cannot cd into project root: $PROJECT_ROOT${NC}" >&2; exit 1; }
+PROJECT_ROOT="."
+HANDOFF_DIR=".ai/handoff"
 
 if [ ! -d "$HANDOFF_DIR" ]; then
     echo -e "${RED}Error: $HANDOFF_DIR not found.${NC}" >&2

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# verify-hooks.sh - Read-only verification of local AAHP git-hook coverage.
+#
+# Given a target repository checkout, this classifies each REQUIRED local hook
+# (from the coverage registry in docs/hook-coverage.md) as one of:
+#   INSTALLED - hook present and byte-identical to the canonical scripts/hooks/ source
+#   DRIFTED   - hook present but its content differs from canonical
+#   EXEMPT    - hook declared exempt for this repo in the registry
+#   UNKNOWN   - required hook not installed, or the repo has no registry contract
+#
+# It MODIFIES NOTHING: it never installs, copies, backs up, or edits a hook. To
+# install or repair hooks, use scripts/install-hooks.sh instead.
+#
+# Usage:
+#   verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]
+#
+# Options:
+#   --repo owner/name   Registry key to look up. Default: derived from the
+#                       target's origin remote, falling back to the dir basename.
+#   --registry FILE     Coverage registry to read. Default: docs/hook-coverage.md
+#                       next to this script.
+#   --quiet             Suppress the banner and info lines; keep the per-hook
+#                       report and the RESULT line.
+#   --help, -h          Show this help.
+#
+# Exit codes:
+#   0 = every required hook is INSTALLED or EXEMPT
+#   1 = at least one required hook is DRIFTED or UNKNOWN (coverage gap)
+#   2 = usage error (bad option, not a git repo, registry missing)
+#
+# The drift comparison uses aahp_checksum (SHA-256, CR-stripped) so a hook
+# checksums identically on a CRLF (Windows) or LF (Linux) working tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+
+CANON_HOOKS="$SCRIPT_DIR/hooks"
+DEFAULT_REGISTRY="$SCRIPT_DIR/../docs/hook-coverage.md"
+REGISTRY_BEGIN="<!-- BEGIN hook-coverage-registry -->"
+REGISTRY_END="<!-- END hook-coverage-registry -->"
+
+TARGET=""
+REPO_SLUG=""
+REGISTRY=""
+QUIET=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)     REPO_SLUG="$2"; shift 2 ;;
+        --registry) REGISTRY="$2"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            echo "Usage: verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$TARGET" ]; then
+                TARGET="$1"; shift
+            else
+                echo "Unexpected argument: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+TARGET="${TARGET:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REGISTRY="${REGISTRY:-$DEFAULT_REGISTRY}"
+
+info() { [ "$QUIET" = true ] || echo "$@"; }
+
+# --- Validate inputs ---------------------------------------------------------
+if [ ! -f "$REGISTRY" ]; then
+    echo "Error: coverage registry not found: $REGISTRY" >&2
+    exit 2
+fi
+if ! git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: $TARGET is not a git repository." >&2
+    exit 2
+fi
+
+# --- Resolve the repo slug ---------------------------------------------------
+if [ -z "$REPO_SLUG" ]; then
+    ORIGIN_URL="$(git -C "$TARGET" remote get-url origin 2>/dev/null || true)"
+    if [ -n "$ORIGIN_URL" ]; then
+        REPO_SLUG="$(printf '%s' "$ORIGIN_URL" \
+            | sed -E 's#^[a-zA-Z]+://[^/]+/##; s#^git@[^:]+:##; s#^ssh://git@[^/]+/##; s#\.git$##')"
+    fi
+    if [ -z "$REPO_SLUG" ]; then
+        REPO_SLUG="$(basename "$(cd "$TARGET" && pwd)")"
+    fi
+fi
+
+# --- Look up the repo row in the registry ------------------------------------
+# Emit a TSV of every registry row, then select the one matching REPO_SLUG.
+ROW="$(awk -v b="$REGISTRY_BEGIN" -v e="$REGISTRY_END" '
+    index($0, b) { inblock = 1; next }
+    index($0, e) { inblock = 0 }
+    inblock && $0 ~ /^[[:space:]]*\|/ {
+        n = split($0, c, "|")
+        for (i = 1; i <= n; i++) { gsub(/^[ \t]+|[ \t]+$/, "", c[i]) }
+        repo = c[2]
+        if (repo == "" || tolower(repo) == "repo") next   # header / stray
+        if (repo ~ /^:?-+:?$/) next                        # separator row
+        printf "%s\t%s\t%s\t%s\t%s\n", repo, c[3], c[4], c[5], c[6]
+    }
+' "$REGISTRY" | awk -F'\t' -v r="$REPO_SLUG" '$1 == r { print; exit }')"
+
+info ""
+info "========================================="
+info "  AAHP hook coverage verify"
+info "========================================="
+info "  Target:   $TARGET"
+info "  Repo:     $REPO_SLUG"
+info "  Registry: $REGISTRY"
+
+if [ -z "$ROW" ]; then
+    echo "  UNKNOWN  repo '$REPO_SLUG' is not declared in the coverage registry."
+    echo "-----------------------------------------"
+    echo "  RESULT: FAIL - no coverage contract for '$REPO_SLUG' (1 unknown)."
+    exit 1
+fi
+
+IFS=$'\t' read -r R_REPO R_TYPE R_REQUIRED R_EXEMPT R_REASON <<< "$ROW"
+: "$R_REPO" "$R_REASON"   # referenced for clarity; not otherwise used
+info "  Type:     $R_TYPE"
+
+# --- Resolve the target's hooks directory (read-only) ------------------------
+HOOKS_DIR="$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$HOOKS_DIR" ]; then
+    case "$HOOKS_DIR" in
+        /*) : ;;
+        *)  HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
+    esac
+else
+    GIT_DIR="$(git -C "$TARGET" rev-parse --git-dir)"
+    case "$GIT_DIR" in
+        /*) : ;;
+        *)  GIT_DIR="$TARGET/$GIT_DIR" ;;
+    esac
+    HOOKS_DIR="$GIT_DIR/hooks"
+fi
+info "  Hooks:    $HOOKS_DIR"
+info ""
+
+# --- Build the required-hook list --------------------------------------------
+REQUIRED_LIST=()
+if [ "$R_REQUIRED" != "none" ] && [ "$R_REQUIRED" != "-" ] && [ -n "$R_REQUIRED" ]; then
+    IFS=',' read -r -a REQUIRED_LIST <<< "$R_REQUIRED"
+fi
+
+hook_is_exempt() {
+    local h="$1" x
+    case "$R_EXEMPT" in
+        ""|"-") return 1 ;;
+        "all")  return 0 ;;
+    esac
+    local ex=()
+    IFS=',' read -r -a ex <<< "$R_EXEMPT"
+    for x in "${ex[@]}"; do
+        [ "$(printf '%s' "$x" | tr -d ' ')" = "$h" ] && return 0
+    done
+    return 1
+}
+
+n_installed=0
+n_drifted=0
+n_exempt=0
+n_unknown=0
+
+if [ "${#REQUIRED_LIST[@]}" -eq 0 ]; then
+    echo "  EXEMPT     (no local hooks required for this repo)"
+    n_exempt=$((n_exempt + 1))
+else
+    for raw in "${REQUIRED_LIST[@]}"; do
+        hook="$(printf '%s' "$raw" | tr -d ' ')"
+        [ -z "$hook" ] && continue
+
+        if hook_is_exempt "$hook"; then
+            echo "  EXEMPT     $hook (declared exempt: $R_REASON)"
+            n_exempt=$((n_exempt + 1))
+            continue
+        fi
+
+        canon="$CANON_HOOKS/$hook"
+        if [ ! -f "$canon" ]; then
+            echo "  UNKNOWN    $hook (no canonical reference in scripts/hooks/)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        dest="$HOOKS_DIR/$hook"
+        if [ ! -f "$dest" ]; then
+            echo "  UNKNOWN    $hook (required hook not installed)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        if [ "$(aahp_checksum "$dest")" = "$(aahp_checksum "$canon")" ]; then
+            echo "  INSTALLED  $hook"
+            n_installed=$((n_installed + 1))
+        else
+            echo "  DRIFTED    $hook (content differs from canonical scripts/hooks/$hook)"
+            n_drifted=$((n_drifted + 1))
+        fi
+    done
+fi
+
+info "-----------------------------------------"
+FAIL=$((n_drifted + n_unknown))
+SUMMARY="installed=$n_installed drifted=$n_drifted exempt=$n_exempt unknown=$n_unknown"
+if [ "$FAIL" -gt 0 ]; then
+    echo "  RESULT: FAIL - $SUMMARY"
+    exit 1
+else
+    echo "  RESULT: PASS - $SUMMARY"
+    exit 0
+fi


### PR DESCRIPTION
## Fleet re-sync: v3.5.0 canonical AAHP gate scripts + local hook tooling

This is the fleet re-sync of the v3.5.0 canonical gate-script fixes from homeofe/improvements into this consumer, plus a refresh of the local hook tooling (AC#6 of homeofe/improvements#8).

### What changed
- Synced the 4 canonical gate scripts: `scripts/{_aahp-lib.sh,lint-handoff.sh,aahp-manifest.sh,verify-handoff.sh}`
  - `aahp-manifest.sh`: adds `--phase documentation` and preserves the existing MANIFEST `project` value on regeneration (cross_repo_ref / project-name preservation)
  - `lint-handoff.sh`: SC2034 fix, relative PII-validator path for native-Windows python, locale-robust (grep -E) email detection
  - `verify-handoff.sh`: path-format-agnostic (cd to project root, relative paths) for cross-platform Windows/Linux CI parity
- Refreshed the local hook tooling: `scripts/install-hooks.sh` (updated) and `scripts/verify-hooks.sh` (added). `scripts/hooks/pre-commit` and `scripts/hooks/pre-push` were already byte-identical and left untouched.

### Preserved per-repo config
- This repo's own `AAHP_HANDOFF_FILES=(...)` line in `scripts/_aahp-lib.sh` was preserved verbatim by the canonical sync tool.
- The MANIFEST was regenerated with this repo's own `scripts/aahp-manifest.sh`, preserving its `tasks` / `next_task_id` and `project`.

### Gate
Local `scripts/verify-handoff.sh . --level ci` passes all 4 layers. CI (`aahp-verify`) gates this PR.

Do not merge automatically; review and merge when ready.